### PR TITLE
Prevent colliding reservations

### DIFF
--- a/HairSuite.Api/Reservations.cs
+++ b/HairSuite.Api/Reservations.cs
@@ -93,9 +93,9 @@ public class ReservationService : IApplicationService<Reservation>
         return stream.Id;
     }
 
-    private bool IsDateReserved(ReservationId id, ReservationDate date) =>
+    private bool IsDateReserved(Reservation reservation) =>
         _documentSession.Query<Reservation>()
-            .Any(other => other.Date.Value == date.Value && other.Status == ReservationStatus.Booked);
+            .Any(other => other.Date.Value == reservation.Date.Value && other.Status == ReservationStatus.Booked);
 }
 
 public interface IApplicationService<T>

--- a/HairSuite.Api/Reservations.cs
+++ b/HairSuite.Api/Reservations.cs
@@ -13,11 +13,15 @@ public class ReservationsController : ControllerBase
     public ReservationsController(IApplicationService<Reservation> service) => _service = service;
 
     [HttpGet("{id:guid}")]
-    public async Task<IActionResult> Query(Guid id, IDocumentSession _documentSession)
+    public async Task<IActionResult> Query(Guid id, IDocumentSession documentSession)
     {
-        var result = await _documentSession.Json.FindByIdAsync<Reservation>(id);
+        var result = await documentSession.Json.FindByIdAsync<Reservation>(id);
         return result == null ? NotFound() : Ok(result);
     }
+
+    [HttpGet]
+    public async Task<IActionResult> Query(IDocumentSession documentSession) =>
+        Ok(await documentSession.Query<Reservation>().ToListAsync());
 
     [HttpPost("make-tentative")]
     public async Task<IActionResult> MakeTentative(Commands.V1.MakeTentativeReservation command) =>
@@ -47,7 +51,8 @@ public class ReservationService : IApplicationService<Reservation>
         var stream = command switch
         {
             Commands.V1.MakeTentativeReservation cmd => Create(cmd),
-            Commands.V1.ConfirmReservation cmd => await GetAndUpdate(cmd),
+            Commands.V1.ConfirmReservation cmd => await GetAndUpdate(cmd.Id,
+                reservation => reservation.Confirm(cmd.Id, IsDateReserved)),
             Commands.V1.RescheduleReservation cmd => await GetAndUpdate(cmd.Id,
                 reservation => reservation.Reschedule(cmd.Id, cmd.Date)),
             Commands.V1.CancelReservation cmd => await GetAndUpdate(cmd.Id, reservation => reservation.Cancel(cmd.Id)),
@@ -71,36 +76,26 @@ public class ReservationService : IApplicationService<Reservation>
 
     private async Task<Guid> GetAndUpdate(Guid id, Action<Reservation> action)
     {
-        var reservation = await _documentSession.Events.AggregateStreamAsync<Reservation>(id);
-        if (reservation == null) throw new Exception($"No such reservation found: {id}");
-
+        var reservation = await RequireReservation(id);
         action(reservation);
-        var events = reservation.DequeueUncommittedEvents();
-        var nextVersion = reservation.Version + events.Length;
-
-        var stream = _documentSession.Events.Append(reservation.ReservationId.Value, nextVersion, events);
-        return stream.Id;
+        return AppendChangesToStream(reservation);
     }
 
-    private async Task<Guid> GetAndUpdate(Commands.V1.ConfirmReservation command)
+    private async Task<Reservation> RequireReservation(Guid id) =>
+        await _documentSession.Events.AggregateStreamAsync<Reservation>(id) ??
+        throw new Exception($"No such reservation found: {id}");
+
+    private Guid AppendChangesToStream(Reservation reservation)
     {
-        var reservation = await _documentSession.Events.AggregateStreamAsync<Reservation>(command.Id);
-        if (reservation == null) throw new Exception($"No such reservation found: {command.Id}");
-
-        var collidingReservations = await _documentSession.Query<Reservation>()
-            .Where(res => res.Date.Value == reservation.Date.Value).ToListAsync();
-
-        bool IsFree() => collidingReservations.All(collision =>
-            collision.Id == reservation.Id || collision.Status != ReservationStatus.Booked || collision.Date != reservation.Date);
-
-        reservation.Confirm(command.Id, IsFree);
-
         var events = reservation.DequeueUncommittedEvents();
         var nextVersion = reservation.Version + events.Length;
-
         var stream = _documentSession.Events.Append(reservation.ReservationId.Value, nextVersion, events);
         return stream.Id;
     }
+
+    private bool IsDateReserved(ReservationId id, ReservationDate date) =>
+        _documentSession.Query<Reservation>()
+            .Any(other => other.Date.Value == date.Value && other.Status == ReservationStatus.Booked);
 }
 
 public interface IApplicationService<T>

--- a/HairSuite.Domain/Reservation.cs
+++ b/HairSuite.Domain/Reservation.cs
@@ -23,14 +23,14 @@ public class Reservation : Aggregate
 
     public static Reservation MakeTentative(Guid id, Guid hairdresserId, DateTime date) => new(id, hairdresserId, date);
 
-    public void Confirm(Guid id, Func<ReservationId, ReservationDate, bool> isDateReserved)
+    public void Confirm(Guid id, Func<Reservation, bool> isDateReserved)
     {
         if (Status != ReservationStatus.Tentative)
         {
             throw new DomainException("Only requested reservations can be confirmed.");
         }
 
-        if (isDateReserved(ReservationId, Date))
+        if (isDateReserved(this))
         {
             throw new DomainException($"The date has already been reserved: {Date.Value}");
         }

--- a/HairSuite.Domain/Reservation.cs
+++ b/HairSuite.Domain/Reservation.cs
@@ -5,20 +5,23 @@ public class Reservation : Aggregate
     public Guid Id
     {
         get => ReservationId.Value;
-        set {}
+        set { }
     }
+
     public ReservationId ReservationId { get; set; }
     public HairdresserId UserId { get; set; }
     public ReservationDate Date { get; set; }
     public ReservationStatus Status { get; set; }
 
-    public Reservation() { } // For serialization
+    // For serialization
+    public Reservation()
+    {
+    }
 
     private Reservation(Guid id, Guid hairdresserId, DateTime date) =>
         HandleEvent(new Events.ReservationRequested(id, hairdresserId, date), Apply);
 
-    public static Reservation MakeTentative(Guid id, Guid hairdresserId, DateTime date) =>
-        new(id, hairdresserId, date);
+    public static Reservation MakeTentative(Guid id, Guid hairdresserId, DateTime date) => new(id, hairdresserId, date);
 
     public void Confirm(Guid id, Func<ReservationId, ReservationDate, bool> isDateReserved)
     {


### PR DESCRIPTION
Prevent colliding reservations by passing a delegate that determines whether a reservation date is free or not to the aggregate.

Two additional changes:
* List all reservations
* Store dates as DateTimeOffset and make sure they are UTC, so that it is `npgsql` complaint